### PR TITLE
Fix typo livenessprove

### DIFF
--- a/airflow/templates/deployments-flower.yaml
+++ b/airflow/templates/deployments-flower.yaml
@@ -36,7 +36,7 @@ spec:
               containerPort: 5555
               protocol: TCP
           args: ["flower"]
-          livenessprobe:
+          livenessProbe:
             httpGet:
               path: "{{ .Values.ingress.flower.path }}/"
               port: flower


### PR DESCRIPTION
I get this error (using k8s 1.8):

`Error: error validating "": error validating data: found invalid field livenessprobe for v1.Container
`
I think it should be liveness**P**robe
